### PR TITLE
removes packages that aren't necessary

### DIFF
--- a/scripts/Ubuntu_16.04_Docker_17.06.sh
+++ b/scripts/Ubuntu_16.04_Docker_17.06.sh
@@ -33,7 +33,7 @@ install_prereqs() {
   update_cmd="sudo apt-get update"
   exec_cmd "$update_cmd"
 
-  install_prereqs_cmd="sudo apt-get -yy install apt-transport-https git python-pip software-properties-common ca-certificates curl linux-image-extra-virtual linux-image-extra-`uname -r`"
+  install_prereqs_cmd="sudo apt-get -yy install apt-transport-https git python-pip software-properties-common ca-certificates curl"
   exec_cmd "$install_prereqs_cmd"
 
   add_docker_repo_keys='curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -'


### PR DESCRIPTION
for https://github.com/Shippable/node/issues/94
these are linux-image-extra packages, which are packages for drivers which is not necessary for install docker