### PR TITLE
boot reqproc on node init. 

### DIFF
--- a/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
@@ -6,6 +6,7 @@ $DOCKER_VERSION = "17.06.2-ee-5"
 $SHIPPABLE_RUNTIME_DIR = "$env:USERPROFILE\shippable"
 $BASE_UUID = New-Guid
 $BASE_DIR = "$SHIPPABLE_RUNTIME_DIR\$BASE_UUID"
+$CONTAINER_BASE_DIR = "C:\Users\ContainerAdministrator\Shippable"
 
 $REQPROC_DIR = "$BASE_DIR\reqProc"
 
@@ -21,6 +22,10 @@ $BUILD_DIR = "$BASE_DIR\build"
 $STATUS_DIR = "$BUILD_DIR\status"
 $SCRIPTS_DIR = "$BUILD_DIR\scripts"
 
+# TODO: move these to reqproc image
+$IMAGE_REQEXEC_DIR = "$CONTAINER_BASE_DIR\reqExec"
+$IMAGE_EXEC_TEMPLATES_DIR = "$CONTAINER_BASE_DIR\execTemplates"
+
 $REQPROC_MOUNTS = ""
 $REQPROC_ENVS = ""
 $REQPROC_OPTS = ""
@@ -28,9 +33,11 @@ $REQPROC_CONTAINER_NAME_PATTERN = "reqProc"
 $REQPROC_CONTAINER_NAME = "$REQPROC_CONTAINER_NAME_PATTERN-$BASE_UUID"
 $REQKICK_SERVICE_NAME_PATTERN = "shippable-reqKick@"
 
+# TODO: update container directories while mounting
 $DEFAULT_TASK_CONTAINER_MOUNTS = "-v ${BUILD_DIR}:${BUILD_DIR} -v ${REQEXEC_DIR}:/reqExec"
 $TASK_CONTAINER_COMMAND = "/reqExec/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/dist/main/main"
 $DEFAULT_TASK_CONTAINER_OPTIONS = "--rm"
+$DOCKER_CLIENT_LATEST = "C:\Program Files\Docker\docker.exe"
 
 Function create_shippable_dir() {
   if (!(Test-Path $SHIPPABLE_RUNTIME_DIR)) {
@@ -143,44 +150,41 @@ Function setup_mounts() {
     mkdir -p $BUILD_DIR
   }
 
-  $REQPROC_MOUNTS="$REQPROC_MOUNTS " + `
-    "-v ${BASE_DIR}:${BASE_DIR} " + `
-    "-v /opt/docker/docker:/usr/bin/docker " + `
-    "-v /var/run/docker.sock:/var/run/docker.sock"
-
-  $DEFAULT_TASK_CONTAINER_MOUNTS="$DEFAULT_TASK_CONTAINER_MOUNTS " + `
-    "-v /opt/docker/docker:/usr/bin/docker " + `
-    "-v /var/run/docker.sock:/var/run/docker.sock"
+  $global:REQPROC_MOUNTS= " -v ${BASE_DIR}:${BASE_DIR} "
 }
 
 Function setup_envs() {
-  $REQPROC_ENVS="$REQPROC_ENVS " + `
-    "-e SHIPPABLE_AMQP_URL=$SHIPPABLE_AMQP_URL " + `
+  $global:REQPROC_ENVS = " -e SHIPPABLE_AMQP_URL=$SHIPPABLE_AMQP_URL " + `
     "-e SHIPPABLE_AMQP_DEFAULT_EXCHANGE=$SHIPPABLE_AMQP_DEFAULT_EXCHANGE " + `
     "-e SHIPPABLE_API_URL=$SHIPPABLE_API_URL " + `
-    "-e LISTEN_QUEUE=$LISTEN_QUEUE " + `
+    "-e LISTEN_QUEUE='$LISTEN_QUEUE' " + `
     "-e NODE_ID=$NODE_ID " + `
     "-e RUN_MODE=$RUN_MODE " + `
     "-e SUBSCRIPTION_ID=$SUBSCRIPTION_ID " + `
     "-e NODE_TYPE_CODE=$NODE_TYPE_CODE " + `
-    "-e BASE_DIR=$BASE_DIR " + `
-    "-e REQPROC_DIR=$REQPROC_DIR " + `
-    "-e REQEXEC_DIR=$REQEXEC_DIR " + `
-    "-e REQEXEC_BIN_DIR=$REQEXEC_BIN_DIR " + `
-    "-e REQKICK_DIR=$REQKICK_DIR " + `
-    "-e BUILD_DIR=$BUILD_DIR " + `
-    "-e REQPROC_CONTAINER_NAME=$REQPROC_CONTAINER_NAME " + `
+    "-e BASE_DIR='$BASE_DIR' " + `
+    "-e REQPROC_DIR='$REQPROC_DIR' " + `
+    "-e REQEXEC_DIR='$REQEXEC_DIR' " + `
+    "-e REQEXEC_BIN_DIR='$REQEXEC_BIN_DIR' " + `
+    "-e REQKICK_DIR='$REQKICK_DIR' " + `
+    "-e BUILD_DIR='$BUILD_DIR' " + `
+    "-e REQPROC_CONTAINER_NAME='$REQPROC_CONTAINER_NAME' " + `
     "-e DEFAULT_TASK_CONTAINER_OPTIONS='$DEFAULT_TASK_CONTAINER_OPTIONS' " + `
     "-e EXEC_IMAGE=$EXEC_IMAGE " + `
-    "-e DOCKER_CLIENT_LATEST=$DOCKER_CLIENT_LATEST " + `
-    "-e SHIPPABLE_DOCKER_VERSION=$DOCKER_VERSION " + `
+    "-e TASK_CONTAINER_COMMAND='$TASK_CONTAINER_COMMAND' " + `
+    "-e DEFAULT_TASK_CONTAINER_MOUNTS='$DEFAULT_TASK_CONTAINER_MOUNTS' " + `
+    "-e DOCKER_CLIENT_LATEST='$DOCKER_CLIENT_LATEST' " + `
+    "-e SHIPPABLE_DOCKER_VERSION='$DOCKER_VERSION' " + `
     "-e IS_DOCKER_LEGACY=false " + `
-    "-e SHIPPABLE_NODE_ARCHITECTURE=$NODE_ARCHITECTURE"
+    "-e SHIPPABLE_NODE_ARCHITECTURE=$NODE_ARCHITECTURE " + `
+    "-e SHIPPABLE_NODE_OPERATING_SYSTEM=$NODE_OPERATING_SYSTEM " + `
+    "-e SHIPPABLE_RELEASE_VERSION=$SHIPPABLE_RELEASE_VERSION " + `
+    "-e IMAGE_EXEC_TEMPLATES_DIR='$IMAGE_EXEC_TEMPLATES_DIR' " + `
+    "-e IMAGE_REQEXEC_DIR='$IMAGE_REQEXEC_DIR' "
 }
 
 Function setup_opts() {
-  $REQPROC_OPTS="$REQPROC_OPTS " + `
-    "-d " + `
+  $global:REQPROC_OPTS= " -d " + `
     "--restart=always " + `
     "--name=$REQPROC_CONTAINER_NAME "
 }
@@ -188,7 +192,9 @@ Function setup_opts() {
 Function boot_reqProc() {
   Write-Output "Boot reqProc..."
   docker pull $EXEC_IMAGE
-  $start_cmd = "docker run $REQPROC_OPTS $REQPROC_MOUNTS $REQPROC_ENVS $EXEC_IMAGE"
+
+  $start_cmd = "docker run $global:REQPROC_OPTS $global:REQPROC_MOUNTS $global:REQPROC_ENVS $EXEC_IMAGE"
+  Write-Output "Executing docker run command: " $start_cmd
   iex "$start_cmd"
 }
 

--- a/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
@@ -186,7 +186,10 @@ Function setup_opts() {
 }
 
 Function boot_reqProc() {
-  Write-Output "!!! TODO: Boot reqProc !!!"
+  Write-Output "Boot reqProc..."
+  docker pull $EXEC_IMAGE
+  $start_cmd = "docker run $REQPROC_OPTS $REQPROC_MOUNTS $REQPROC_ENVS $EXEC_IMAGE"
+  iex "$start_cmd"
 }
 
 Function boot_reqKick() {


### PR DESCRIPTION
https://github.com/Shippable/node/issues/211

- boots up new reqProc container when init script runs

```
docker run  -d --restart=always --name=reqProc-faf4a787-aefd-4a9e-a82b-13ac33c4afb2   -v C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2:C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2   -e SHIPPABLE_AMQP_URL=amqp://jitaceqowutuxuyo:RHezSyq2QyHfkYW9@localhost:5672/shippable -e SHIPPABLE_AMQP_DEFAULT_EXCHANGE=shippableEx -e SHIPPABLE_API_URL=https://d9271d66.ngrok.io -e LISTEN_QUEUE='5a1ff4f2c5d1a321009de90d.x86_64.WindowsServer_2016.req' -e NODE_ID=5a20d63a4802ed2000a0da80 -e RUN_MODE=dev -e SUBSCRIPTION_ID=5a1ff4f2c5d1a321009de90d -e NODE_TYPE_CODE=7000 -e BASE_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2' -e REQPROC_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\reqProc' -e REQEXEC_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\reqExec' -e REQEXEC_BIN_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\reqExec\bin' -e REQKICK_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\reqKick' -e BUILD_DIR='C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\build' -e REQPROC_CONTAINER_NAME='reqProc-faf4a787-aefd-4a9e-a82b-13ac33c4afb2' -e DEFAULT_TASK_CONTAINER_OPTIONS='--rm' -e EXEC_IMAGE=drydock/w16reqproc:master -e TASK_CONTAINER_COMMAND='/reqExec/x86_64/WindowsServer_2016/dist/main/main' -e DEFAULT_TASK_CONTAINER_MOUNTS='-v C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\build:C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\build -v C:\Users\niranjan\shippable\faf4a787-aefd-4a9e-a82b-13ac33c4afb2\reqExec:/reqExec' -e DOCKER_CLIENT_LATEST='C:\Program Files\Docker\docker.exe' -e SHIPPABLE_DOCKER_VERSION='17.06.2-ee-5' -e IS_DOCKER_LEGACY=false -e SHIPPABLE_NODE_ARCHITECTURE=x86_64 -e SHIPPABLE_NODE_OPERATING_SYSTEM=WindowsServer_2016 -e SHIPPABLE_RELEASE_VERSION=master -e IMAGE_EXEC_TEMPLATES_DIR='C:\Users\ContainerAdministrator\Shippable\execTemplates' -e IMAGE_REQEXEC_DIR='C:\Users\ContainerAdministrator\Shippable\reqExec'  drydock/w16reqproc:master
```

able to boot up reqproc
```
2017-12-01T07:55:06.353Z - error:  Error: connect ECONNREFUSED 127.0.0.1:5672
    at Object.exports._errnoException (util.js:907:11)
    at exports._exceptionWithHostPort (util.js:930:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1081:14)
2017-12-01T07:55:06.353Z - verbose: Since an error occurred, re-connecting reqProc to Q amqp://jitaceqowutuxuyo:RHezSyq2QyHfkYW9@localhost:5672/shippable
2017-12-01T07:55:06.353Z - warn: Failed to close connection from reqProc to Q amqp://jitaceqowutuxuyo:RHezSyq2QyHfkYW9@localhost:5672/shippable
2017-12-01T07:55:06.353Z - verbose: Waiting for 32 seconds before re-connecting reqProc to Q amqp://jitaceqowutuxuyo:RHezSyq2QyHfkYW9@localhost:5672/shippable
```
---

**TODO** in next PRs
- update mount paths inside the container to use `ContainerAdministrator`
- add function to delete all existing reqproc containers. 
