### PR TITLE
adds get_integration_resource_keys for *nix

### DIFF
--- a/shipctl/aarch64/Ubuntu_16.04/utility.sh
+++ b/shipctl/aarch64/Ubuntu_16.04/utility.sh
@@ -98,6 +98,25 @@ get_params_resource() {
   eval echo "$""$UP"_PARAMS_"$PARAMNAME"
 }
 
+get_integration_resource_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_resource_keys RESOURCE_NAME"
+    exit 99
+  fi
+  UP=$(get_resource_name "$1")
+  RESOURCE_META=$(get_resource_meta $UP)
+  if [ ! -d $RESOURCE_META ]; then
+    echo "IN directory not present for resource: $1"
+    exit 99
+  fi
+  RESOURCE_INTEGRATION_ENV_FILE=$RESOURCE_META/integration.env
+  if [ ! -f $RESOURCE_INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for resource: $1"
+    exit 99
+  fi
+  cat $RESOURCE_INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
 get_integration_resource_field() {
   if [ "$1" == "" ] || [ "$2" == "" ]; then
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"

--- a/shipctl/x86_64/CentOS_7/utility.sh
+++ b/shipctl/x86_64/CentOS_7/utility.sh
@@ -98,6 +98,25 @@ get_params_resource() {
   eval echo "$""$UP"_PARAMS_"$PARAMNAME"
 }
 
+get_integration_resource_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_resource_keys RESOURCE_NAME"
+    exit 99
+  fi
+  UP=$(get_resource_name "$1")
+  RESOURCE_META=$(get_resource_meta $UP)
+  if [ ! -d $RESOURCE_META ]; then
+    echo "IN directory not present for resource: $1"
+    exit 99
+  fi
+  RESOURCE_INTEGRATION_ENV_FILE=$RESOURCE_META/integration.env
+  if [ ! -f $RESOURCE_INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for resource: $1"
+    exit 99
+  fi
+  cat $RESOURCE_INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
 get_integration_resource_field() {
   if [ "$1" == "" ] || [ "$2" == "" ]; then
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"

--- a/shipctl/x86_64/Ubuntu_14.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_14.04/utility.sh
@@ -98,6 +98,25 @@ get_params_resource() {
   eval echo "$""$UP"_PARAMS_"$PARAMNAME"
 }
 
+get_integration_resource_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_resource_keys RESOURCE_NAME"
+    exit 99
+  fi
+  UP=$(get_resource_name "$1")
+  RESOURCE_META=$(get_resource_meta $UP)
+  if [ ! -d $RESOURCE_META ]; then
+    echo "IN directory not present for resource: $1"
+    exit 99
+  fi
+  RESOURCE_INTEGRATION_ENV_FILE=$RESOURCE_META/integration.env
+  if [ ! -f $RESOURCE_INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for resource: $1"
+    exit 99
+  fi
+  cat $RESOURCE_INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
 get_integration_resource_field() {
   if [ "$1" == "" ] || [ "$2" == "" ]; then
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"

--- a/shipctl/x86_64/Ubuntu_16.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_16.04/utility.sh
@@ -98,6 +98,25 @@ get_params_resource() {
   eval echo "$""$UP"_PARAMS_"$PARAMNAME"
 }
 
+get_integration_resource_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_resource_keys RESOURCE_NAME"
+    exit 99
+  fi
+  UP=$(get_resource_name "$1")
+  RESOURCE_META=$(get_resource_meta $UP)
+  if [ ! -d $RESOURCE_META ]; then
+    echo "IN directory not present for resource: $1"
+    exit 99
+  fi
+  RESOURCE_INTEGRATION_ENV_FILE=$RESOURCE_META/integration.env
+  if [ ! -f $RESOURCE_INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for resource: $1"
+    exit 99
+  fi
+  cat $RESOURCE_INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
 get_integration_resource_field() {
   if [ "$1" == "" ] || [ "$2" == "" ]; then
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"

--- a/shipctl/x86_64/macOS_10.12/utility.sh
+++ b/shipctl/x86_64/macOS_10.12/utility.sh
@@ -98,6 +98,25 @@ get_params_resource() {
   eval echo "$""$UP"_PARAMS_"$PARAMNAME"
 }
 
+get_integration_resource_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_resource_keys RESOURCE_NAME"
+    exit 99
+  fi
+  UP=$(get_resource_name "$1")
+  RESOURCE_META=$(get_resource_meta $UP)
+  if [ ! -d $RESOURCE_META ]; then
+    echo "IN directory not present for resource: $1"
+    exit 99
+  fi
+  RESOURCE_INTEGRATION_ENV_FILE=$RESOURCE_META/integration.env
+  if [ ! -f $RESOURCE_INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for resource: $1"
+    exit 99
+  fi
+  cat $RESOURCE_INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
 get_integration_resource_field() {
   if [ "$1" == "" ] || [ "$2" == "" ]; then
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"


### PR DESCRIPTION
https://github.com/Shippable/node/issues/295

#### YML
```yml
name: x86-64-ubuntu-16-04-host-shipctl-get-integration-resource-keys
type: runSh
runtime:
  architecture: x86_64
  nodePool: x8664u16custom
  container: false
flags:
  - x86-64
  - ubuntu-16-04
  - x86-64-ubuntu-16-04-host-shipctl
  - rc-cd_master_rSync
steps:
  - IN: x86-64-trigger
  - IN: windows-server-2016-trigger
  - IN: checking-do-integration
  - IN: master-cluster
  - TASK:
      name: check-digital-ocean-integration
      script:
        - printenv
        - shipctl get_integration_resource_keys checking-do-integration
  - TASK:
      name: check-aws-integration-in-cluster
      script:
        - printenv
        - shipctl get_integration_resource_keys master-cluster
```

#### Output

![image](https://user-images.githubusercontent.com/4211715/35272763-5d3cbb5a-005c-11e8-8471-ef69734f743a.png)

Build link : https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-ubuntu-16-04-host-shipctl-get-integration-resource-keys/builds/5a66f02f744bc4050007e15d/console