### PR TITLE
adds get_integration_resource_keys for windows

### DIFF
--- a/shipctl/x86_64/WindowsServer_2016/utility.ps1
+++ b/shipctl/x86_64/WindowsServer_2016/utility.ps1
@@ -112,6 +112,22 @@ function get_params_resource([string] $resource, [string] $param) {
     return _get_env_value $key;
 }
 
+function get_integration_resource_keys([string] $resource) {
+    if (-not $resource) {
+        throw "Usage: shipctl get_integration_resource_keys RESOURCE"
+    }
+    $up = get_resource_name $resource
+    $resMetaDirectory = get_resource_meta $resource
+    if (!(Test-Path "$resMetaDirectory")) {
+        throw "IN directory not present for resource: $resource"
+    }
+    $resIntegrationEnvFile = Join-Path "$resMetaDirectory" "integration.env"
+    if (!(Test-Path "$resIntegrationEnvFile")) {
+        throw "integration.env not present for resource: $resource"
+    }
+    Get-Content $resIntegrationEnvFile | %{ $_.Split('=')[0] }
+}
+
 function get_integration_resource_field([string] $resource, [string] $field) {
     if (-not $resource -or -not $field) {
         throw "Usage: shipctl get_integration_resource_field RESOURCE FIELD"


### PR DESCRIPTION
https://github.com/Shippable/node/issues/297

#### YML
```yml
  - name: x86-64-windows-server-2016-host-shipctl-get-integration-resource-keys
    type: runSh
    runtime:
      architecture: x86_64
      nodePool: custom__x86_64__WindowsServer_2016
      container: false
    flags:
      - x86-64
      - windows-server-2016
      - x86-64-windows-server-2016-host-shipctl
    steps:
      - IN: x86-64-trigger
      - IN: windows-server-2016-trigger
      - IN: checking-do-integration
      - IN: master-cluster
      - TASK:
          name: check-digital-ocean-integration
          script:
            - gci env:*
            - shipctl get_integration_resource_keys checking-do-integration
      - TASK:
          name: check-aws-integration-in-cluster
          script:
            - gci env:*
            - shipctl get_integration_resource_keys master-cluster
```

#### Output
![image](https://user-images.githubusercontent.com/4211715/35273259-03205742-005e-11e8-9b40-e724fd117d03.png)

Build Link: https://rcapp.shippable.com/github/sample-organisation/jobs/x86-64-windows-server-2016-host-shipctl-get-integration-resource-keys/builds/5a67175c394af60500322c02/console