### PR TITLE
adds docker options for U16 nodes in /etc/docker/daemon.json

### DIFF
--- a/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
@@ -146,26 +146,10 @@ docker_install() {
 
 check_docker_opts() {
   # SHIPPABLE docker options required for every node
-  echo "Checking docker options"
+  echo "Adding docker options"
 
-  SHIPPABLE_DOCKER_OPTS='DOCKER_OPTS="$DOCKER_OPTS -H unix:///var/run/docker.sock -g=/data --storage-driver aufs"'
-  opts_exist=$(sudo sh -c "grep '$SHIPPABLE_DOCKER_OPTS' /etc/default/docker || echo ''")
-
-  if [ -z "$opts_exist" ]; then
-    ## docker opts do not exist
-    echo "Removing existing DOCKER_OPTS in /etc/default/docker, if any"
-    sed -i '/^DOCKER_OPTS/d' "/etc/default/docker"
-
-    echo "appending DOCKER_OPTS to /etc/default/docker"
-    sudo sh -c "echo '$SHIPPABLE_DOCKER_OPTS' >> /etc/default/docker"
-    docker_restart=true
-  else
-    echo "Shippable docker options already present in /etc/default/docker"
-  fi
-
-  ## remove the docker option to listen on all ports
-  echo "Disabling docker tcp listener"
-  sudo sh -c "sed -e s/\"-H tcp:\/\/0.0.0.0:4243\"//g -i /etc/default/docker"
+  echo '{"graph": "/data", "storage-driver": "aufs"}' > /etc/docker/daemon.json
+  docker_restart=true
 }
 
 restart_docker_service() {

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
@@ -143,26 +143,10 @@ docker_install() {
 
 check_docker_opts() {
   # SHIPPABLE docker options required for every node
-  echo "Checking docker options"
+  echo "Adding docker options"
 
-  SHIPPABLE_DOCKER_OPTS='DOCKER_OPTS="$DOCKER_OPTS -H unix:///var/run/docker.sock -g=/data"'
-  opts_exist=$(sh -c "grep '$SHIPPABLE_DOCKER_OPTS' /etc/default/docker || echo ''")
-
-  # DOCKER_OPTS do not exist or match.
-  if [ -z "$opts_exist" ]; then
-    echo "Removing existing DOCKER_OPTS in /etc/default/docker, if any"
-    sed -i '/^DOCKER_OPTS/d' "/etc/default/docker"
-
-    echo "Appending DOCKER_OPTS to /etc/default/docker"
-    sh -c "echo '$SHIPPABLE_DOCKER_OPTS' >> /etc/default/docker"
-    docker_restart=true
-  else
-    echo "Shippable docker options already present in /etc/default/docker"
-  fi
-
-  ## remove the docker option to listen on all ports
-  echo "Disabling docker tcp listener"
-  sh -c "sed -e s/\"-H tcp:\/\/0.0.0.0:4243\"//g -i /etc/default/docker"
+  echo '{"graph": "/data", "storage-driver": "aufs"}' > /etc/docker/daemon.json
+  docker_restart=true
 }
 
 restart_docker_service() {


### PR DESCRIPTION
https://github.com/Shippable/node/issues/306
https://github.com/Shippable/node/issues/306
- verified using `sudo docker info` command  all the docker options are getting set correctly

NOTE: As per the docker [docs](https://docs.docker.com/engine/admin/systemd/#custom-docker-daemon-options) its recommended using `graph` for setting root directory.

