### PR TITLE
Configure proxy for systemd based systems minus aarch

### DIFF
--- a/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
@@ -151,6 +151,27 @@ check_docker_opts() {
   docker_restart=true
 }
 
+add_docker_proxy_envs() {
+  mkdir -p /etc/systemd/system/docker.service.d
+  proxy_envs="[Service]\nEnvironment="
+
+  if [ ! -z "$SHIPPABLE_HTTP_PROXY" ]; then
+    proxy_envs="$proxy_envs \"HTTP_PROXY=$SHIPPABLE_HTTP_PROXY\""
+  fi
+
+  if [ ! -z "$SHIPPABLE_HTTPS_PROXY" ]; then
+    proxy_envs="$proxy_envs \"HTTPS_PROXY=$SHIPPABLE_HTTPS_PROXY\""
+  fi
+
+  if [ ! -z "$SHIPPABLE_NO_PROXY" ]; then
+    proxy_envs="$proxy_envs \"NO_PROXY=$SHIPPABLE_NO_PROXY\""
+  fi
+
+  echo -e "$proxy_envs" > /etc/systemd/system/docker.service.d/proxy.conf
+  # Maybe don't restart always. We seem to restart in check_docker_opts always anyway, so leaving this is a future enhancement.
+  docker_restart=true
+}
+
 restart_docker_service() {
   echo "checking if docker restart is necessary"
   if [ $docker_restart == true ]; then
@@ -241,6 +262,11 @@ main() {
 
   trap before_exit EXIT
   exec_grp "check_docker_opts"
+
+  if [ ! -z "$SHIPPABLE_HTTP_PROXY" ] || [ ! -z "$SHIPPABLE_HTTPS_PROXY" ] || [ ! -z "$SHIPPABLE_NO_PROXY" ]; then
+    trap before_exit EXIT
+    exec_grp "add_docker_proxy_envs"
+  fi
 
   trap before_exit EXIT
   exec_grp "restart_docker_service"

--- a/initScripts/x86_64/Ubuntu_16.04/boot.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/boot.sh
@@ -140,6 +140,21 @@ setup_envs() {
     -e SHIPPABLE_NODE_ARCHITECTURE=$NODE_ARCHITECTURE \
     -e SHIPPABLE_NODE_OPERATING_SYSTEM=$NODE_OPERATING_SYSTEM \
     -e SHIPPABLE_RELEASE_VERSION=$SHIPPABLE_RELEASE_VERSION"
+
+    if [ ! -z "$SHIPPABLE_HTTP_PROXY" ]; then
+      REQPROC_ENVS="$REQPROC_ENVS \
+        -e http_proxy=$SHIPPABLE_HTTP_PROXY"
+    fi
+
+    if [ ! -z "$SHIPPABLE_HTTPS_PROXY" ]; then
+      REQPROC_ENVS="$REQPROC_ENVS \
+        -e https_proxy=$SHIPPABLE_HTTPS_PROXY"
+    fi
+
+    if [ ! -z "$SHIPPABLE_NO_PROXY" ]; then
+      REQPROC_ENVS="$REQPROC_ENVS \
+        -e no_proxy=$SHIPPABLE_NO_PROXY"
+    fi
 }
 
 setup_opts() {


### PR DESCRIPTION
https://github.com/Shippable/node/issues/328

**Note:** This does not include ARM as we seem to configure both init.d and systemd in it. (Reference: https://github.com/Shippable/node/blob/master/initScripts/aarch64/Ubuntu_16.04/Docker_17.09.sh#L155). I need to setup an ARM machine to explore this further.