### PR TITLE
Run systemctl daemon-reload to ensure newer config is used

### DIFF
--- a/initScripts/x86_64/CentOS_7/Docker_17.06.sh
+++ b/initScripts/x86_64/CentOS_7/Docker_17.06.sh
@@ -195,6 +195,7 @@ restart_docker_service() {
   echo "checking if docker restart is necessary"
   if [ $docker_restart == true ]; then
     echo "restarting docker service on reset"
+    exec_cmd "systemctl daemon-reload"
     exec_cmd "systemctl restart docker"
   else
     echo "docker_restart set to false, not restarting docker daemon"

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
@@ -179,6 +179,7 @@ restart_docker_service() {
   echo "checking if docker restart is necessary"
   if [ $docker_restart == true ]; then
     echo "restarting docker service on reset"
+    exec_cmd "systemctl daemon-reload"
     exec_cmd "sudo service docker restart"
   else
     echo "docker_restart set to false, not restarting docker daemon"

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
@@ -176,6 +176,7 @@ restart_docker_service() {
   echo "checking if docker restart is necessary"
   if [ $docker_restart == true ]; then
     echo "restarting docker service on reset"
+    exec_cmd "systemctl daemon-reload"
     exec_cmd "service docker restart"
   else
     echo "docker_restart set to false, not restarting docker daemon"


### PR DESCRIPTION
https://github.com/Shippable/node/issues/328
systemd caches config until we force it to reload it. This was missed while copy-pasting the script from my test environment.