### PR TITLE
checks if package exists before removing reqkick and reqproc

### DIFF
--- a/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
@@ -34,14 +34,14 @@ Function install_prereqs() {
   $git_package = Get-Package git -provider ChocolateyGet -ErrorAction SilentlyContinue
   if (!$git_package) {
     Write-Output "Installing git"
-    Install-Package -ProviderName ChocolateyGet -Name git -Force
+    choco install -y git
   }
 
   Write-Output "Checking for nssm"
   $nssm_package = Get-Package nssm -provider ChocolateyGet -ErrorAction SilentlyContinue
   if (!$nssm_package) {
     Write-Output "Installing nssm"
-    Install-Package -ProviderName ChocolateyGet -Name nssm -Force
+    choco install -y nssm
   }
 
   Write-Output "Refreshing PATH"

--- a/initScripts/x86_64/WindowsServer_2016/boot.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/boot.ps1
@@ -85,15 +85,21 @@ Function remove_reqKick() {
   }
 
   # remove nssm managed reqkick services
-  Get-Service shippable-reqkick-* | %{
-    nssm stop $_.Name
-    nssm remove $_.Name confirm
+  if (Get-Command "nssm" -ErrorAction SilentlyContinue)
+  {
+    Get-Service shippable-reqkick-* | %{
+      nssm stop $_.Name
+      nssm remove $_.Name confirm
+    }
   }
 }
 
 Function remove_reqProc() {
   Write-Output "Remove existing reqProc containers"
-  docker ps -a --filter "NAME=$REQPROC_CONTAINER_NAME_PATTERN" --format '{{.Names}}' | %{ docker rm -f $_ }
+  if (Get-Command "docker" -ErrorAction SilentlyContinue)
+  {
+    docker ps -a --filter "NAME=$REQPROC_CONTAINER_NAME_PATTERN" --format '{{.Names}}' | %{ docker rm -f $_ }
+  }
 }
 
 Function setup_dirs() {


### PR DESCRIPTION
https://github.com/Shippable/node/issues/339

Currently, if we run the script on a fresh node, it fails in `remove_reqProc` with `docker command not found` error. So, adding the check to remove docker only if docker is installed. 

If git and nssm are not installed, and trying to install them with `Install-Package` throws the following error
![image](https://user-images.githubusercontent.com/4211715/36368186-2005e79a-157c-11e8-8139-271aa9620cf4.png)

So, changing the script to install with `choco`