### PR TITLE
 sets correct path of java in shipctl centos

### DIFF
--- a/shipctl/x86_64/CentOS_7/shippable_jdk
+++ b/shipctl/x86_64/CentOS_7/shippable_jdk
@@ -44,7 +44,7 @@ shippable_jdk() {
   elif [ "$JDK_VERSION" == "openjdk8" ]; then
     export_java_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64";
     set_java_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64/jre/bin/java";
-    set_javac_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64/bin/javac";
+    set_javac_path "/usr/java/jdk1.8.0_161/bin/javac";
   elif [ "$JDK_VERSION" == "openjdk9" ]; then
     export_java_path "/usr/lib/jvm/java-9-openjdk-9.0.0.163-1.el7.centos.x86_64";
     set_java_path "/usr/lib/jvm/java-9-openjdk-9.0.0.163-1.el7.centos.x86_64/bin/java";

--- a/shipctl/x86_64/CentOS_7/shippable_jdk
+++ b/shipctl/x86_64/CentOS_7/shippable_jdk
@@ -4,11 +4,14 @@ JDK_VERSION=$2
 
 export_java_path() {
   directory=$1;
+  echo "hello printing directory: $directory"
   if [ -d "$directory" ]; then
     export JAVA_HOME="$directory";
     export PATH="$PATH:$directory/bin";
+    echo "java home $JAVA_HOME"
+    echo "path $PATH"
   else
-    echo "$JDK_VERSION is not supported on this image"
+    echo "$JDK_VERSION is not supported on this image 1"
     exit 99
   fi
 }
@@ -18,7 +21,7 @@ set_java_path() {
   if [ -f $java_path ]; then
     sudo update-alternatives --set java $java_path
   else
-    echo "$JDK_VERSION is not supported on this image"
+    echo "$JDK_VERSION is not supported on this image 2"
     exit 99
   fi
 }
@@ -28,7 +31,7 @@ set_javac_path() {
   if [ -f $javac_path ]; then
     sudo update-alternatives --set javac $javac_path
   else
-    echo "$JDK_VERSION is not supported on this image"
+    echo "$JDK_VERSION is not supported on this image 3"
     exit 99
   fi
 }

--- a/shipctl/x86_64/CentOS_7/shippable_jdk
+++ b/shipctl/x86_64/CentOS_7/shippable_jdk
@@ -4,14 +4,11 @@ JDK_VERSION=$2
 
 export_java_path() {
   directory=$1;
-  echo "hello printing directory: $directory"
   if [ -d "$directory" ]; then
     export JAVA_HOME="$directory";
     export PATH="$PATH:$directory/bin";
-    echo "java home $JAVA_HOME"
-    echo "path $PATH"
   else
-    echo "$JDK_VERSION is not supported on this image 1"
+    echo "$JDK_VERSION is not supported on this image"
     exit 99
   fi
 }
@@ -21,7 +18,7 @@ set_java_path() {
   if [ -f $java_path ]; then
     sudo update-alternatives --set java $java_path
   else
-    echo "$JDK_VERSION is not supported on this image 2"
+    echo "$JDK_VERSION is not supported on this image"
     exit 99
   fi
 }
@@ -31,7 +28,7 @@ set_javac_path() {
   if [ -f $javac_path ]; then
     sudo update-alternatives --set javac $javac_path
   else
-    echo "$JDK_VERSION is not supported on this image 3"
+    echo "$JDK_VERSION is not supported on this image"
     exit 99
   fi
 }
@@ -44,7 +41,7 @@ shippable_jdk() {
   elif [ "$JDK_VERSION" == "openjdk8" ]; then
     export_java_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64";
     set_java_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64/jre/bin/java";
-    set_javac_path "/usr/java/jdk1.8.0_161/bin/javac";
+    set_javac_path "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.x86_64/bin/javac";
   elif [ "$JDK_VERSION" == "openjdk9" ]; then
     export_java_path "/usr/lib/jvm/java-9-openjdk-9.0.0.163-1.el7.centos.x86_64";
     set_java_path "/usr/lib/jvm/java-9-openjdk-9.0.0.163-1.el7.centos.x86_64/bin/java";
@@ -52,7 +49,7 @@ shippable_jdk() {
   elif [ "$JDK_VERSION" == "oraclejdk8" ]; then
     export_java_path "/usr/java/jre1.8.0_161";
     set_java_path "/usr/java/jre1.8.0_161/bin/java";
-    set_javac_path "/usr/java/jre1.8.0_161/bin/javac";
+    set_javac_path "/usr/java/jdk1.8.0_161/bin/javac";
   elif [ "$JDK_VERSION" == "oraclejdk9" ]; then
     export_java_path "/usr/java/jdk-9.0.4";
     set_java_path "/usr/java/jdk-9.0.4/bin/java";


### PR DESCRIPTION
https://github.com/Shippable/node/issues/355

- Verified this by building c7 container by cloning my nodeRepo and then running `shipctl jdk set` command for each java version on the built c7 image.

```
[root@a50f394734b0 /]# shipctl jdk set oraclejdk8
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
[root@a50f394734b0 /]# shipctl jdk set oraclejdk9
java version "9.0.4"
Java(TM) SE Runtime Environment (build 9.0.4+11)
Java HotSpot(TM) 64-Bit Server VM (build 9.0.4+11, mixed mode)
[root@a50f394734b0 /]# shipctl jdk set openjdk7  
java version "1.7.0_161"
OpenJDK Runtime Environment (rhel-2.6.12.0.el7_4-x86_64 u161-b00)
OpenJDK 64-Bit Server VM (build 24.161-b00, mixed mode)
[root@a50f394734b0 /]# shipctl jdk set openjdk8
openjdk version "1.8.0_161"
OpenJDK Runtime Environment (build 1.8.0_161-b14)
OpenJDK 64-Bit Server VM (build 25.161-b14, mixed mode)
[root@a50f394734b0 /]# shipctl jdk set openjdk9
openjdk version "9-ea"
OpenJDK Runtime Environment (build 9-ea+163)
OpenJDK 64-Bit Server VM (build 9-ea+163, mixed mode)
```