### PR TITLE
#368; adds shippable_jdk for aarch64.

### DIFF
--- a/shipctl/aarch64/Ubuntu_16.04/install.sh
+++ b/shipctl/aarch64/Ubuntu_16.04/install.sh
@@ -16,6 +16,9 @@ cp $SRC_DIR/shippable_retry /usr/local/bin/shippable_retry
 echo "Installing shippable_replace"
 cp $SRC_DIR/shippable_replace /usr/local/bin/shippable_replace
 
+echo "Installing shippable_jdk"
+cp $SRC_DIR/shippable_jdk /usr/local/bin/shippable_jdk
+
 echo "Installing shipctl"
 cp $SRC_DIR/shipctl /usr/local/bin/shipctl
 

--- a/shipctl/aarch64/Ubuntu_16.04/shipctl
+++ b/shipctl/aarch64/Ubuntu_16.04/shipctl
@@ -18,7 +18,9 @@ execute_shipctl_command() {
   fi
 }
 
-if [ "$shipctl_command" == "retry" ]; then
+if [ "$shipctl_command" == "jdk" ]; then
+  execute_shipctl_command shippable_jdk $arguments
+elif [ "$shipctl_command" == "retry" ]; then
   execute_shipctl_command shippable_retry $arguments
 elif [ "$shipctl_command" == "decrypt" ]; then
   execute_shipctl_command shippable_decrypt $arguments

--- a/shipctl/aarch64/Ubuntu_16.04/shippable_jdk
+++ b/shipctl/aarch64/Ubuntu_16.04/shippable_jdk
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+service_action=$1
+JDK_VERSION=$2
+
+export_java_path() {
+  directory=$1;
+  if [ -d "$directory" ]; then
+    export JAVA_HOME="$directory";
+    export PATH="$PATH:$directory/bin";
+  else
+    echo "$JDK_VERSION is not supported on this image"
+    exit 99
+  fi
+}
+
+set_java_path() {
+  java_path=$1
+  if [ -f $java_path ]; then
+    sudo update-alternatives --set java $java_path
+  else
+    echo "$JDK_VERSION is not supported on this image"
+    exit 99
+  fi
+}
+
+set_javac_path() {
+  javac_path=$1
+  if [ -f $javac_path ]; then
+    sudo update-alternatives --set javac $javac_path
+  else
+    echo "$JDK_VERSION is not supported on this image"
+    exit 99
+  fi
+}
+
+shippable_jdk() {
+  if [ "$JDK_VERSION" == "openjdk7" ]; then
+    export_java_path "/usr/lib/jvm/java-7-openjdk-arm64";
+    set_java_path "/usr/lib/jvm/java-7-openjdk-arm64/jre/bin/java";
+    set_javac_path "/usr/lib/jvm/java-7-openjdk-arm64/bin/javac";
+  elif [ "$JDK_VERSION" == "openjdk8" ]; then
+    export_java_path "/usr/lib/jvm/java-8-openjdk-arm64";
+    set_java_path "/usr/lib/jvm/java-8-openjdk-arm64/jre/bin/java";
+    set_javac_path "/usr/lib/jvm/java-8-openjdk-arm64/bin/javac";
+  elif [ "$JDK_VERSION" == "oraclejdk8" ]; then
+    export_java_path "/usr/lib/jvm/java-8-oracle";
+    set_java_path "/usr/lib/jvm/java-8-oracle/jre/bin/java";
+    set_javac_path "/usr/lib/jvm/java-8-oracle/bin/javac";
+  else
+    echo "The version of the jdk you are trying to use is not supported. The supported versions include openjdk7, openjdk8, and oraclejdk8"
+    exit 99
+  fi
+
+  java -version
+}
+
+if [ "$JDK_VERSION" == "" ] || [ "$service_action" == "" ]; then
+  echo "Usage: shippable_jdk set openjdk8"
+  exit 1
+fi
+
+if  [ "$service_action" != "set" ]; then
+  echo "Unknown command: $service_action"
+  echo "Usage: shippable_jdk set openjdk8"
+  exit 1
+fi
+
+shippable_jdk


### PR DESCRIPTION
#368

Matches the `shippable_jdk` for `x86_64`, except with the supported versions and paths for `aarch64`.  Each supported version could be set using the commands.