### PR TITLE
#376; correct reqKick service name on dynamic 16.04 nodes.

### DIFF
--- a/initScripts/x86_64/Ubuntu_16.04/boot.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/boot.sh
@@ -47,6 +47,7 @@ check_input() {
 export_envs() {
   export SHIPPABLE_RUNTIME_DIR="/var/lib/shippable"
   if [ "$NODE_TYPE_CODE" -eq 7001 ]; then
+    export BASE_UUID="$NODE_ID"
     export BASE_DIR="$SHIPPABLE_RUNTIME_DIR"
   else
     export BASE_UUID="$(cat /proc/sys/kernel/random/uuid)"


### PR DESCRIPTION
#376 

This will just be used in the reqKick service name, and is the ID we use for genExec/reqProc. 