### PR TITLE
Sets DOCKER_NAT_IP in boot script

### DIFF
--- a/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/Docker_17.06.ps1
@@ -106,9 +106,6 @@ Function check_docker_opts() {
 
   # Output docker info
   & "docker" info
-
-  # Get docker NAT gateway ip address
-  $global:DOCKER_NAT_IP=(Get-NetIPConfiguration | Where-Object InterfaceAlias -eq "vEthernet (HNS Internal NIC)").IPv4Address.IPAddress
 }
 
 Function pull_reqProc() {

--- a/initScripts/x86_64/WindowsServer_2016/boot.ps1
+++ b/initScripts/x86_64/WindowsServer_2016/boot.ps1
@@ -147,6 +147,9 @@ Function setup_mounts() {
 }
 
 Function setup_envs() {
+  # Get docker NAT gateway ip address
+  $DOCKER_NAT_IP=(Get-NetIPConfiguration | Where-Object InterfaceAlias -eq "vEthernet (HNS Internal NIC)").IPv4Address.IPAddress
+
   $global:REQPROC_ENVS = " -e SHIPPABLE_AMQP_URL=$SHIPPABLE_AMQP_URL " + `
     "-e SHIPPABLE_AMQP_DEFAULT_EXCHANGE=$SHIPPABLE_AMQP_DEFAULT_EXCHANGE " + `
     "-e SHIPPABLE_API_URL=$SHIPPABLE_API_URL " + `


### PR DESCRIPTION
https://github.com/Shippable/node/issues/381

We are doing this, as Windows dynamic nodes are not picking up the first build, but not the second build as the `DOCKER_NAT_IP` was not getting set in boot script.

Verified by initializing a custom node and running builds twice on the same node.