### PR TITLE
#376; change reqKick template on dynamic nodes.

### DIFF
--- a/initScripts/x86_64/Ubuntu_16.04/boot.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/boot.sh
@@ -235,6 +235,10 @@ boot_reqKick() {
   cp $REQKICK_SERVICE_DIR/shippable-reqKick@.service.template /etc/systemd/system/shippable-reqKick@.service
   chmod 644 /etc/systemd/system/shippable-reqKick@.service
 
+  if [ "$NODE_TYPE_CODE" -eq 7001 ]; then
+    sed -i "s#/var/lib/shippable/%i/reqKick/reqKick.app.js#/var/lib/shippable/reqKick/reqKick.app.js#g" /etc/systemd/system/shippable-reqKick@.service
+  fi
+
   local reqkick_env_template=$REQKICK_SERVICE_DIR/shippable-reqKick.env.template
   local reqkick_env_file=$REQKICK_CONFIG_DIR/$BASE_UUID.env
   touch $reqkick_env_file


### PR DESCRIPTION
#376 

Remove the `%i` from the path because the path in an AMI won't have a UUID.