### PR TITLE
adds systemctl enable docker command to initScripts

### DIFF
--- a/initScripts/x86_64/CentOS_7/Docker_17.06.sh
+++ b/initScripts/x86_64/CentOS_7/Docker_17.06.sh
@@ -169,6 +169,9 @@ docker_install() {
 
   remove_static_docker_binary='rm -rf /tmp/docker'
   exec_cmd "$remove_static_docker_binary"
+
+  enable_docker='systemctl enable docker'
+  exec_cmd "$enable_docker"
 }
 
 check_docker_opts() {

--- a/initScripts/x86_64/RHEL_7/Docker_17.06.sh
+++ b/initScripts/x86_64/RHEL_7/Docker_17.06.sh
@@ -180,6 +180,9 @@ docker_install() {
 
   remove_static_docker_binary='rm -rf /tmp/docker'
   exec_cmd "$remove_static_docker_binary"
+
+  enable_docker='systemctl enable docker'
+  exec_cmd "$enable_docker"
 }
 
 check_docker_opts() {

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_1.13.sh
@@ -145,6 +145,9 @@ docker_install() {
 
   remove_static_docker_binary='rm -rf /tmp/docker'
   exec_cmd "$remove_static_docker_binary"
+
+  enable_docker='systemctl enable docker'
+  exec_cmd "$enable_docker"
 }
 
 check_docker_opts() {

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_17.06.sh
@@ -154,6 +154,9 @@ docker_install() {
 
   remove_static_docker_binary='rm -rf /tmp/docker'
   exec_cmd "$remove_static_docker_binary"
+
+  enable_docker='systemctl enable docker'
+  exec_cmd "$enable_docker"
 }
 
 check_docker_opts() {


### PR DESCRIPTION
https://github.com/Shippable/node/issues/384

- Verified by running initScripts, when containers came did `sudo reboot ` and then logged in to the machine again to verify if containers are still up (`docker ps`). Earlier containers were not coming up post reboot.