### PR TITLE
add missing envs to u16 for dynamic nodes

### DIFF
--- a/initScripts/x86_64/Ubuntu_16.04/boot.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/boot.sh
@@ -62,11 +62,13 @@ export_envs() {
   export BUILD_DIR="$BASE_DIR/build"
   export STATUS_DIR=$BUILD_DIR/status
   export SCRIPTS_DIR=$BUILD_DIR/scripts
-  export REQPROC_MOUNTS=""
-  export REQPROC_ENVS=""
-  export REQPROC_OPTS=""
+  # This is set while booting dynamic nodes
+  export REQPROC_MOUNTS="$REQPROC_MOUNTS"
+  export REQPROC_ENVS="$REQPROC_ENVS"
+  export REQPROC_OPTS="$REQPROC_OPTS"
   export REQPROC_CONTAINER_NAME_PATTERN="reqProc"
   export EXEC_CONTAINER_NAME_PATTERN="shippable-exec"
+
   if [ "$NODE_TYPE_CODE" -eq 7001 ]; then
     export REQPROC_CONTAINER_NAME="$REQPROC_CONTAINER_NAME_PATTERN-$NODE_ID"
   else


### PR DESCRIPTION
#397 

also can compare to the u14 version:
https://github.com/Shippable/node/blob/master/initScripts/x86_64/Ubuntu_14.04/boot.sh#L68