### PR TITLE
adds bump_version shipctl function in u14,c7 and rhel7

### DIFF
--- a/shipctl/x86_64/CentOS_7/utility.sh
+++ b/shipctl/x86_64/CentOS_7/utility.sh
@@ -410,3 +410,38 @@ put_resource_state_multi() {
     echo $a >> "$JOB_STATE/$RES.env"
   done
 }
+
+bump_version() {
+  local version_to_bump=$1
+  local action=$2
+  local major=$(echo "$version_to_bump" | cut -d "." -f 1 | sed "s/v//")
+  local minor=$(echo "$version_to_bump" | cut -d "." -f 2)
+  local patch=$(echo "$version_to_bump" | cut -d "." -f 3)
+  if ! [[ $action == "major" || $action == "minor" || $action == "patch" ]]; then
+    echo "error: Invalid action given in the argument." >&2; exit 99
+  fi
+  local numRegex='^[0-9]+$'
+  if ! [[ $major =~ $numRegex && $minor =~ $numRegex && $patch =~ $numRegex ]] ; then
+    echo "error: Invalid semantics given in the argument." >&2; exit 99
+  fi
+  if [[ $(echo "$version_to_bump" | cut -d "." -f 1) == $major ]]; then
+    appendV=false
+  else
+    appendV=true
+  fi
+  if [[ $action == "major" ]]; then
+    major=$((major + 1))
+    minor=0
+    patch=0
+  elif [[ $action == "minor" ]]; then
+    minor=$((minor + 1))
+    patch=0
+  elif [[ $action == "patch" ]]; then
+    patch=$((patch + 1))
+  fi
+  local new_version="$major.$minor.$patch"
+  if [[ $appendV == true ]]; then
+    new_version="v$new_version"
+  fi
+  echo $new_version
+}

--- a/shipctl/x86_64/RHEL_7/utility.sh
+++ b/shipctl/x86_64/RHEL_7/utility.sh
@@ -410,3 +410,38 @@ put_resource_state_multi() {
     echo $a >> "$JOB_STATE/$RES.env"
   done
 }
+
+bump_version() {
+  local version_to_bump=$1
+  local action=$2
+  local major=$(echo "$version_to_bump" | cut -d "." -f 1 | sed "s/v//")
+  local minor=$(echo "$version_to_bump" | cut -d "." -f 2)
+  local patch=$(echo "$version_to_bump" | cut -d "." -f 3)
+  if ! [[ $action == "major" || $action == "minor" || $action == "patch" ]]; then
+    echo "error: Invalid action given in the argument." >&2; exit 99
+  fi
+  local numRegex='^[0-9]+$'
+  if ! [[ $major =~ $numRegex && $minor =~ $numRegex && $patch =~ $numRegex ]] ; then
+    echo "error: Invalid semantics given in the argument." >&2; exit 99
+  fi
+  if [[ $(echo "$version_to_bump" | cut -d "." -f 1) == $major ]]; then
+    appendV=false
+  else
+    appendV=true
+  fi
+  if [[ $action == "major" ]]; then
+    major=$((major + 1))
+    minor=0
+    patch=0
+  elif [[ $action == "minor" ]]; then
+    minor=$((minor + 1))
+    patch=0
+  elif [[ $action == "patch" ]]; then
+    patch=$((patch + 1))
+  fi
+  local new_version="$major.$minor.$patch"
+  if [[ $appendV == true ]]; then
+    new_version="v$new_version"
+  fi
+  echo $new_version
+}

--- a/shipctl/x86_64/Ubuntu_14.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_14.04/utility.sh
@@ -410,3 +410,38 @@ put_resource_state_multi() {
     echo $a >> "$JOB_STATE/$RES.env"
   done
 }
+
+bump_version() {
+  local version_to_bump=$1
+  local action=$2
+  local major=$(echo "$version_to_bump" | cut -d "." -f 1 | sed "s/v//")
+  local minor=$(echo "$version_to_bump" | cut -d "." -f 2)
+  local patch=$(echo "$version_to_bump" | cut -d "." -f 3)
+  if ! [[ $action == "major" || $action == "minor" || $action == "patch" ]]; then
+    echo "error: Invalid action given in the argument." >&2; exit 99
+  fi
+  local numRegex='^[0-9]+$'
+  if ! [[ $major =~ $numRegex && $minor =~ $numRegex && $patch =~ $numRegex ]] ; then
+    echo "error: Invalid semantics given in the argument." >&2; exit 99
+  fi
+  if [[ $(echo "$version_to_bump" | cut -d "." -f 1) == $major ]]; then
+    appendV=false
+  else
+    appendV=true
+  fi
+  if [[ $action == "major" ]]; then
+    major=$((major + 1))
+    minor=0
+    patch=0
+  elif [[ $action == "minor" ]]; then
+    minor=$((minor + 1))
+    patch=0
+  elif [[ $action == "patch" ]]; then
+    patch=$((patch + 1))
+  fi
+  local new_version="$major.$minor.$patch"
+  if [[ $appendV == true ]]; then
+    new_version="v$new_version"
+  fi
+  echo $new_version
+}


### PR DESCRIPTION
https://github.com/Shippable/node/issues/414
https://github.com/Shippable/node/issues/416
https://github.com/Shippable/node/issues/417

```
[root@b72839dcef5b shipctl]# rpm --query centos-release
centos-release-7-4.1708.el7.centos.x86_64
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version 5.1.2 major)
6.0.0
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version 5.1.2 minor)
5.2.0
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version 5.1.2 patch)
5.1.3
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version v5.1.2 patch)
v5.1.3
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version v5.1.2 minor)
v5.2.0
[root@b72839dcef5b shipctl]# echo $(shipctl bump_version v5.1.2 major)
v6.0.0
[root@b72839dcef5b shipctl]# 

```
```
root@9c28e2426201:/shipctl# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.5 LTS
Release:	14.04
Codename:	trusty
root@9c28e2426201:/shipctl# echo $(shipctl bump_version 5.1.2 major)
6.0.0
root@9c28e2426201:/shipctl# echo $(shipctl bump_version 5.1.2 minor)
5.2.0
root@9c28e2426201:/shipctl# echo $(shipctl bump_version 5.1.2 patch)
5.1.3
root@9c28e2426201:/shipctl# echo $(shipctl bump_version v5.1.2 patch)
v5.1.3
root@9c28e2426201:/shipctl# echo $(shipctl bump_version v5.1.2 mino)
error: Invalid action given in the argument.

root@9c28e2426201:/shipctl# echo $(shipctl bump_version v5.1.2 minor)
v5.2.0
root@9c28e2426201:/shipctl# echo $(shipctl bump_version v5.1.2 major)
v6.0.0
root@9c28e2426201:/shipctl# 

```