### PR TITLE
adds bump_version shipctl function for windows

### DIFF
--- a/shipctl/x86_64/WindowsServer_2016/utility.ps1
+++ b/shipctl/x86_64/WindowsServer_2016/utility.ps1
@@ -383,7 +383,8 @@ function bump_version([string] $version_to_bump, [string] $action) {
     }
     $versionParts = $version_to_bump.Split("{.}")
     $majorWithoutV = $versionParts[0].Replace("v", "")
-    if (-not ($majorWithoutV -match "^[\d\.]+$" -and $versionParts[1] -match "^[\d\.]+$" -and $versionParts[2] -match "^[\d\.]+$")) {
+    if (-not ($majorWithoutV -match "^[\d\.]+$" -and $versionParts[1] -match "^[\d\.]+$" -and
+        $versionParts[2] -match "^[\d\.]+$")) {
         throw "error: Invalid semantics given in the argument."
     }
     if ($action -ne "major" -and $action -ne "minor" -and $action -ne "patch") {

--- a/shipctl/x86_64/WindowsServer_2016/utility.ps1
+++ b/shipctl/x86_64/WindowsServer_2016/utility.ps1
@@ -376,3 +376,43 @@ function put_resource_state_multi([string] $resourceName) {
         "$state`n" | Out-File -Encoding utf8 -NoNewLine -Append -FilePath "$resourceEnvFile"
     }
 }
+
+function bump_version([string] $version_to_bump, [string] $action) {
+    if (-not $version_to_bump -or -not $action) {
+        throw "Usage: shipctl bump_version version_to_bump action"
+    }
+    $versionParts = $version_to_bump.Split("{.}")
+    $majorWithoutV = $versionParts[0].Replace("v", "")
+    if (-not ($majorWithoutV -match "^[\d\.]+$" -and $versionParts[1] -match "^[\d\.]+$" -and $versionParts[2] -match "^[\d\.]+$")) {
+        throw "error: Invalid semantics given in the argument."
+    }
+    if ($action -ne "major" -and $action -ne "minor" -and $action -ne "patch") {
+        throw "error: Invalid action given in the argument."
+    }
+    $major = [int]$majorWithoutV
+    $minor = [int]$versionParts[1]
+    $patch = [int]$versionParts[2]
+    if ( $versionParts[0] -eq $majorWithoutV) {
+        $appendV = $false
+    }
+    else {
+        $appendV = $true
+    }
+    if ($action -eq "major") {
+        $major = $major + 1
+        $minor = 0
+        $patch = 0
+    }
+    ElseIf ($action -eq "minor") {
+        $minor = $minor + 1
+        $patch = 0
+    }
+    ElseIf ($action -eq "patch") {
+        $patch = $patch + 1
+    }
+    $newVersion = [string]$major + "." + [string]$minor + "." + [string]$patch
+    if ($appendV) {
+        $newVersion = "v" + $newVersion
+    }
+    Write-Output $newVersion
+}


### PR DESCRIPTION
https://github.com/Shippable/node/issues/418

```
PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version 1.2.3 major
2.0.0

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version v1.2.3 major
v2.0.0

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version v1.2.3 minor
v1.3.0

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version v1.2.3 patch
v1.2.4

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version 1.2.3 patch
1.2.4

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version 1.2.3 minor
1.3.0

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version 1.2.x minor
execute_shiptctl_command : error: Invalid semantics given in the argument.
At C:\Program Files\Shippable\shipctl.ps1:44 char:5
+     execute_shiptctl_command $shipctl_command
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,execute_shiptctl_command
 

PS C:\Users\Administrator\node\shipctl\x86_64\WindowsServer_2016> shipctl bump_version 1.2.x 
execute_shiptctl_command : Usage: shipctl bump_version version_to_bump action
At C:\Program Files\Shippable\shipctl.ps1:44 char:5
+     execute_shiptctl_command $shipctl_command
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,execute_shiptctl_command
```