### PR TITLE
Removing the patch version for JQ

### DIFF
--- a/shipctl/x86_64/Ubuntu_14.04/install.sh
+++ b/shipctl/x86_64/Ubuntu_14.04/install.sh
@@ -4,7 +4,7 @@ readonly SRC_DIR=$(dirname "$0")
 
 if ! [ -x "$(command -v jq)" ]; then
   echo "Installing jq"
-  apt-get install -y jq=1.3-1.1ubuntu1
+  apt-get install -y jq=1.3*
 fi
 
 echo "Installing shippable_decrypt"


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/10795

Removing patched version of jq from this file: https://github.com/Shippable/node/blob/master/shipctl/x86_64/Ubuntu_14.04/install.sh#L7