### PR TITLE
adds oraclejdk7 support for u16

### DIFF
--- a/shipctl/x86_64/Ubuntu_16.04/shippable_jdk
+++ b/shipctl/x86_64/Ubuntu_16.04/shippable_jdk
@@ -46,6 +46,10 @@ shippable_jdk() {
     export_java_path "/usr/lib/jvm/java-9-openjdk-amd64";
     set_java_path "/usr/lib/jvm/java-9-openjdk-amd64/bin/java";
     set_javac_path "/usr/lib/jvm/java-9-openjdk-amd64/bin/javac";
+  elif [ "$JDK_VERSION" == "oraclejdk7" ]; then
+    export_java_path "/usr/lib/jvm/java-7-oracle";
+    set_java_path "/usr/lib/jvm/java-7-oracle/jre/bin/java";
+    set_javac_path "/usr/lib/jvm/java-7-oracle/bin/javac";
   elif [ "$JDK_VERSION" == "oraclejdk8" ]; then
     export_java_path "/usr/lib/jvm/java-8-oracle";
     set_java_path "/usr/lib/jvm/java-8-oracle/jre/bin/java";


### PR DESCRIPTION
https://github.com/Shippable/node/issues/439

The following tests were done on drydock/u14javall on a Ubuntu 16.04 custom node.

Before changes,

- v5.6.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/21/1/console
- v5.5.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/27/1/console
- v5.4.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/27/1/console
- latest : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/29/1/console

All jobs result in the following error message.
![image](https://user-images.githubusercontent.com/4211715/40102414-13c22f1e-5908-11e8-855b-a8a498ebb90e.png)

After changes,
- v5.6.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/30/1/console ( failed with error: oraclejdk7 is not supported on this image )
- v5.5.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/32/1/console (success)
- v5.4.1 : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/31/1/console (success)
- latest : https://rcapp.shippable.com/github/vishnu-shippable/my-ci-test/runs/33/1/console ( failed with error: oraclejdk7 is not supported on this image )