### PR TITLE
add new shipctl utilities for directly used integrations in runSh jobs

### DIFF
--- a/shipctl/aarch32/Ubuntu_16.04/utility.sh
+++ b/shipctl/aarch32/Ubuntu_16.04/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/aarch64/Ubuntu_16.04/utility.sh
+++ b/shipctl/aarch64/Ubuntu_16.04/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/x86_64/CentOS_7/utility.sh
+++ b/shipctl/x86_64/CentOS_7/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/x86_64/RHEL_7/utility.sh
+++ b/shipctl/x86_64/RHEL_7/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/x86_64/Ubuntu_14.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_14.04/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/x86_64/Ubuntu_16.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_16.04/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"

--- a/shipctl/x86_64/WindowsServer_2016/utility.ps1
+++ b/shipctl/x86_64/WindowsServer_2016/utility.ps1
@@ -142,6 +142,35 @@ function get_integration_resource_field([string] $resource, [string] $field) {
     return _get_env_value $key
 }
 
+function get_integration_keys([string] $integration) {
+    if (-not $integration) {
+        throw "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    }
+    $integrationEnvFile = Join-Path "$env:JOB_INTEGRATIONS" "integration.env"
+    if (!(Test-Path "$integrationEnvFile")) {
+        throw "integration.env not present for integration: $integration"
+    }
+    Get-Content $integrationEnvFile | %{ $_.Split('=')[0] }
+}
+
+function get_integration_field([string] $integration, [string] $field) {
+    if (-not $integration -or -not $field) {
+        throw "Usage: shipctl get_integration_field INTEGRATION_NAME FIELD"
+    }
+    $integrationJsonFile = Join-Path "$env:JOB_INTEGRATIONS" "$integration\integration.json"
+    if (!(Test-Path "$integrationJsonFile")) {
+        throw "integration.json not present for integration: $integration"
+    }
+    $masterName = get_json_value $integrationJsonFile "masterName"
+    if ($masterName -eq "keyValuePair") {
+      return _get_env_value $field
+    }
+    $up = _sanitize_upper $integration
+    $intKeyName = _sanitize_upper $field
+    $key = $up + "_INTEGRATION_" + $intKeyName
+    return _get_env_value $key
+}
+
 function get_resource_version_name([string] $resource) {
     if (-not $resource) {
         throw "Usage: shipctl get_resource_version_name RESOURCE"

--- a/shipctl/x86_64/macOS_10.12/utility.sh
+++ b/shipctl/x86_64/macOS_10.12/utility.sh
@@ -131,6 +131,38 @@ get_integration_resource_field() {
   fi
 }
 
+get_integration_keys() {
+  if [ "$1" == "" ]; then
+    echo "Usage: shipctl get_integration_keys INTEGRATION_NAME"
+    exit 99
+  fi
+  INTEGRATION_ENV_FILE=$JOB_INTEGRATIONS/$1/integration.env
+  if [ ! -f $INTEGRATION_ENV_FILE ]; then
+    echo "integration.env not present for integration: $1"
+    exit 99
+  fi
+  cat $INTEGRATION_ENV_FILE | awk -F "=" '{print $1}'
+}
+
+get_integration_field() {
+  if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: shipctl get_integration_field INTEGRATION_NAME KEY_NAME"
+    exit 99
+  fi
+  INTEGRATION_JSON_FILE=$JOB_INTEGRATIONS/$1/integration.json
+  if [ ! -f $INTEGRATION_JSON_FILE ]; then
+    echo "integration.json not present for integration: $1"
+    exit 99
+  fi
+  if [ $(jq -r '.masterName' $INTEGRATION_JSON_FILE) == "keyValuePair" ]; then
+    eval echo "$""$2"
+  else
+    UP=$(sanitize_shippable_string "$(to_uppercase "$1")")
+    INTKEYNAME=$(sanitize_shippable_string "$(to_uppercase "$2")")
+    eval echo "$""$UP"_INTEGRATION_"$INTKEYNAME"
+  fi
+}
+
 get_resource_version_name() {
   if [ "$1" == "" ]; then
     echo "Usage: shipctl get_resource_version_name RESOURCE_NAME"


### PR DESCRIPTION
#486

[reference](https://github.com/Shippable/reqProc/pull/433#issue-201952367)

Just like `get_integration_resource_keys` and `get_integration_resource_field`, we need to add 2 new
utilities for direct integrations.
1. `get_integration_keys`
2. `get_integration_field`