### PR TITLE
fixes get_integration_resource_field

### DIFF
--- a/shipctl/x86_64/CentOS_7/utility.sh
+++ b/shipctl/x86_64/CentOS_7/utility.sh
@@ -122,7 +122,8 @@ get_integration_resource_field() {
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"
     exit 99
   fi
-  if [ $(get_integration_resource "$1" masterName) == "keyValuePair" ]; then
+  RESOURCE_INTEGRATION_MASTERNAME=$(get_integration_resource "$1" masterName)
+  if [ "$RESOURCE_INTEGRATION_MASTERNAME" == "keyValuePair" ]; then
     eval echo "$""$2"
   else
     UP=$(get_resource_name "$1")

--- a/shipctl/x86_64/RHEL_7/utility.sh
+++ b/shipctl/x86_64/RHEL_7/utility.sh
@@ -122,7 +122,8 @@ get_integration_resource_field() {
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"
     exit 99
   fi
-  if [ $(get_integration_resource "$1" masterName) == "keyValuePair" ]; then
+  RESOURCE_INTEGRATION_MASTERNAME=$(get_integration_resource "$1" masterName)
+  if [ "$RESOURCE_INTEGRATION_MASTERNAME" == "keyValuePair" ]; then
     eval echo "$""$2"
   else
     UP=$(get_resource_name "$1")

--- a/shipctl/x86_64/Ubuntu_14.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_14.04/utility.sh
@@ -122,7 +122,8 @@ get_integration_resource_field() {
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"
     exit 99
   fi
-  if [ $(get_integration_resource "$1" masterName) == "keyValuePair" ]; then
+  RESOURCE_INTEGRATION_MASTERNAME=$(get_integration_resource "$1" masterName)
+  if [ "$RESOURCE_INTEGRATION_MASTERNAME" == "keyValuePair" ]; then
     eval echo "$""$2"
   else
     UP=$(get_resource_name "$1")

--- a/shipctl/x86_64/Ubuntu_16.04/utility.sh
+++ b/shipctl/x86_64/Ubuntu_16.04/utility.sh
@@ -122,7 +122,8 @@ get_integration_resource_field() {
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"
     exit 99
   fi
-  if [ $(get_integration_resource "$1" masterName) == "keyValuePair" ]; then
+  RESOURCE_INTEGRATION_MASTERNAME=$(get_integration_resource "$1" masterName)
+  if [ "$RESOURCE_INTEGRATION_MASTERNAME" == "keyValuePair" ]; then
     eval echo "$""$2"
   else
     UP=$(get_resource_name "$1")

--- a/shipctl/x86_64/macOS_10.12/utility.sh
+++ b/shipctl/x86_64/macOS_10.12/utility.sh
@@ -122,7 +122,8 @@ get_integration_resource_field() {
     echo "Usage: shipctl get_integration_resource_field RESOURCE_NAME KEY_NAME"
     exit 99
   fi
-  if [ $(get_integration_resource "$1" masterName) == "keyValuePair" ]; then
+  RESOURCE_INTEGRATION_MASTERNAME=$(get_integration_resource "$1" masterName)
+  if [ "$RESOURCE_INTEGRATION_MASTERNAME" == "keyValuePair" ]; then
     eval echo "$""$2"
   else
     UP=$(get_resource_name "$1")


### PR DESCRIPTION
https://github.com/Shippable/node/issues/496

Verified by running 

- *nix runCI job: https://app.shippable.com/github/sample-organisation/app-mono/runs/51/1/console
- *nix runSh job: https://app.shippable.com/github/sample-organisation/jobs/verify-v-6-7-4/builds/5b597a7cb161f70700b4a132/console
- Windows Server runCI job: not supported
- Windows Server runSh job: https://rcapp.shippable.com/github/vishnu-shippable/jobs/shipctl-checking/builds/5b5985c0a876e70700be6bf2/console

For Windows, the following snippet does not cause any errors, as powershell does not expect quoting like bash.
```powershell
$myvar = "spaces in the env"

if ( $myvar -eq "keyvalue" ) {
  echo "inside if and value is $myvar"
} else {
  echo "inside else and value is $myvar"
}
```

